### PR TITLE
Use explicit foreground color

### DIFF
--- a/src/components/Browser.css
+++ b/src/components/Browser.css
@@ -44,4 +44,5 @@
   width: 100%;
   height: 100%;
   padding: 6px;
+  color: black;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@ html, body {
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 11px;
+  color: black;
 }
 
 *, *:before, *:after {


### PR DESCRIPTION
By default, Firefox uses system colors. On Linux with a dark theme, this
means that everything is rendered with the explicit white background and
the theme defined white foreground. You will agree that it is not very convenient ;)