### PR TITLE
Fix a crash when there is no __compat field in property support data

### DIFF
--- a/src/lib/Declaration.js
+++ b/src/lib/Declaration.js
@@ -49,7 +49,7 @@ Declaration.prototype.processCompatPath = function (compatPath, compatPathData, 
   const unprefixedProperty = postcss.vendor.unprefixed(this.node.prop)
   const propertyCompatData = objectPath.get(compatData.css.properties, compatPath)
 
-  if (!propertyCompatData) return
+  if (!propertyCompatData || !propertyCompatData.__compat) return
 
   const propertySuppport = propertyCompatData.__compat.support
 


### PR DESCRIPTION
Just added a simple check. While there in no problem right now, this is the cause of a crash for my next PR. I send it as a separated PR because it should be harmless and may be usefull even if my next PR is not accepted ;)